### PR TITLE
Move to preconfigured Resin-SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Changed
+
+- Moved to [resin-sdk-preconfigured](https://github.com/resin-io-modules/resin-sdk-preconfigured)
+
 ## [1.0.1] - 2015-12-04
 
 ### Changed

--- a/build/utils.js
+++ b/build/utils.js
@@ -16,7 +16,7 @@ limitations under the License.
  */
 var resin;
 
-resin = require('resin-sdk');
+resin = require('resin-sdk-preconfigured');
 
 
 /**

--- a/lib/utils.coffee
+++ b/lib/utils.coffee
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 ###
 
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 
 ###*
 # @summary Get config partition information

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "bluebird": "^3.0.5",
     "resin-image-fs": "^2.1.1",
-    "resin-sdk": "^4.0.0",
+    "resin-sdk-preconfigured": "^0.1.0",
     "rindle": "^1.0.0",
     "string-to-stream": "^1.0.1"
   }

--- a/tests/utils.spec.coffee
+++ b/tests/utils.spec.coffee
@@ -1,6 +1,6 @@
 m = require('mochainon')
 Promise = require('bluebird')
-resin = require('resin-sdk')
+resin = require('resin-sdk-preconfigured')
 utils = require('../lib/utils')
 
 describe 'Utils:', ->


### PR DESCRIPTION
This PR is interesting because it doesn't work, and I'm not sure why.

Having investigated further, I eventually tried just re-running [the last master build](https://travis-ci.org/resin-io/resin-config-json/jobs/101637412), and it turns out that nowadays that doesn't pass _either_, presumably because of changes in Resin itself sometime in the last year.

The error we hit both then and now is a 'no such file or directory', in a deep trace from `fatfs` from `resin-image-fs`. I don't really have any context on what exactly this is trying to do, or what changes we've done in the last year that might have broken it. I can dig in more myself if need be, but it seems like using your expert knowledge might be quicker. Any suggestions, or any idea who else might be good to talk to about this?